### PR TITLE
feat: 채팅 서비스에 spring event 도입

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/tradechat/dto/TradeChatMessageDto.kt
+++ b/backend/src/main/java/org/example/backend/domain/tradechat/dto/TradeChatMessageDto.kt
@@ -7,9 +7,9 @@ import java.time.LocalDateTime
 data class TradeChatMessageDto(
     val messageId: Long,
     val senderId: Long?,
-    val senderNickname: String,
+    val senderNickname: String?,
     val content: String,
-    val sendDate: LocalDateTime
+    val sendDate: LocalDateTime?
 ) {
     companion object {
         @JvmStatic

--- a/backend/src/main/java/org/example/backend/domain/tradechat/event/AsyncConfig.kt
+++ b/backend/src/main/java/org/example/backend/domain/tradechat/event/AsyncConfig.kt
@@ -1,0 +1,23 @@
+package org.example.backend.domain.tradechat.event
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+    @Bean(name = ["taskExecutor"])
+    fun threadPoolTaskExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 5    // 기본 스레드 수
+        executor.maxPoolSize = 10    // 최대 스레드 수
+        executor.queueCapacity = 50  // 대기 큐 용량
+        executor.setThreadNamePrefix("ChatAsync-")
+        executor.initialize()
+        return executor
+    }
+}
+

--- a/backend/src/main/java/org/example/backend/domain/tradechat/event/TradeChatMessageEvent.kt
+++ b/backend/src/main/java/org/example/backend/domain/tradechat/event/TradeChatMessageEvent.kt
@@ -1,0 +1,8 @@
+package org.example.backend.domain.tradechat.event
+
+import org.example.backend.domain.tradechat.dto.TradeChatMessageDto
+
+data class TradeChatMessageEvent(
+    val roomId: Long,
+    val messageDto: TradeChatMessageDto
+)

--- a/backend/src/main/java/org/example/backend/domain/tradechat/event/TradeChatMessageListener.kt
+++ b/backend/src/main/java/org/example/backend/domain/tradechat/event/TradeChatMessageListener.kt
@@ -1,0 +1,64 @@
+package org.example.backend.domain.tradechat.event
+
+import lombok.RequiredArgsConstructor
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+@RequiredArgsConstructor
+@EnableAsync
+class TradeChatMessageListener(
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+
+    /**
+     * == DB에 저장된(커밋된) 메시지만 비동기적으로 전송 ==
+     *
+     * - 이전 방식: 메시지 저장과 전송이 같은 트랜잭션내 처리
+     *   - 서버 직렬화로 인해 전송이 지연되는 병목 발생
+     *   - 예. 메시지0 저장(200ms) -> 메시지0 전송(200ms) -> 메시지1 저장(200ms) -> 메시지1 전송(200ms) -> ..
+     *
+     * - 개선 방식:
+     *   - DB 저장이 완료된 메시지는 이벤트를 발행하여 별도 스레드에서 비동기 전송 처리
+     *   - 병렬적으로 처리가능 -> 응답 지연 개선
+     *   - 예. 메시지0 저장(200ms) -> 메시지1 저장(200ms) -> ..
+     *          ↘ 메시지0 전송         ↘ 메시지1 전송
+     *
+     * - 안정성
+     *   - WebSocket 전송 실패 가능성 대비, 최대 3회까지 재전송 시도
+     */
+    @Async("taskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleTradeChatMessageEvent(event: TradeChatMessageEvent) {
+        val maxRetry = 3 // 최대 재시도 횟수
+        var attempt = 0
+        var sent = false
+
+        while (!sent && attempt < maxRetry) {
+            try {
+                messagingTemplate.convertAndSend("/receive/" + event.roomId, event.messageDto)
+                sent = true
+            } catch (e: Exception) {
+                attempt++
+                // 로그 기록
+                System.err.println("메시지 전송 실패, 재시도 " + attempt + "회: " + e.message)
+
+                try {
+                    Thread.sleep(100L * attempt) // 재시도 간 짧은 딜레이
+                } catch (ie: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
+            }
+        }
+
+        if (!sent) {
+            // 최종 실패 시 알람, DB 기록 등 추가 처리 가능
+            System.err.println("메시지 전송 최종 실패: roomId=" + event.roomId)
+        }
+    }
+}
+

--- a/backend/src/main/java/org/example/backend/domain/tradechat/service/TradeChatService.kt
+++ b/backend/src/main/java/org/example/backend/domain/tradechat/service/TradeChatService.kt
@@ -8,12 +8,15 @@ import org.example.backend.domain.tradechat.dto.TradeChatRoomDto
 import org.example.backend.domain.tradechat.entity.ChatStatus
 import org.example.backend.domain.tradechat.entity.TradeChatMessage
 import org.example.backend.domain.tradechat.entity.TradeChatRoom
+import org.example.backend.domain.tradechat.event.TradeChatMessageEvent
 import org.example.backend.domain.tradechat.repository.TradeChatMessageRepository
 import org.example.backend.domain.tradechat.repository.TradeChatRoomRepository
 import org.example.backend.global.exception.BusinessException
 import org.example.backend.global.exception.ErrorCode
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service
+
 
 @Service
 class TradeChatService(
@@ -21,7 +24,8 @@ class TradeChatService(
     private val chatMessageRepository: TradeChatMessageRepository,
     private val tradeRepository: TradeRepository,
     private val memberRepository: MemberRepository,
-    private val messagingTemplate: SimpMessagingTemplate
+    private val messagingTemplate: SimpMessagingTemplate,
+    private val eventPublisher: ApplicationEventPublisher
 ) {
 
     // 메시지 전송
@@ -36,7 +40,8 @@ class TradeChatService(
         val savedMessage = chatMessageRepository.save(message)
         val messageDto = TradeChatMessageDto.from(savedMessage)
 
-        messagingTemplate.convertAndSend("/receive/$roomId", messageDto)
+        // 트랜잭션 커밋 후 이벤트 발행
+        eventPublisher.publishEvent(TradeChatMessageEvent(roomId, messageDto))
     }
 
     // 로그인 사용자의 채팅방 목록 조회


### PR DESCRIPTION
## 📎 Issue 번호<!-- 이슈 번호를 적어주세요 -->
<!-- closed #번호 --> closed #77

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- `TradeChatService`의 `sendMessage()` 로직에 spring event 도입
- 채팅 도메인을 자바에서 코틀린으로 변환하며 생긴 에러 수정


## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### 1. Spring event 도입
**[메시지 전송 프로세스]**
메시지를 DB에 저장 ➡️ WebSocket에게 메시지 전송 요청 ➡️ WebSocket이 메시지를 클라이언트에게 전송
이때, 메시지 DB 저장, WebSocket에게 메시지 전송 요청 작업은 서버에서 발생

**[기존 방식]**
메시지 전송 프로세스가 한 트랜잭션에서 발생
➡️ 서버는 작업을 직렬화하므로, 전송이 지연되는 병목 현상이 발생할 수 있음
예. `메시지0 저장(200ms)` → `메시지0 전송 요청(200ms)` → `메시지1 저장(200ms)` → `메시지1 전송 요청(200ms)` ..

**[변경 방식]**
DB 저장(커밋)이 완료된 메시지들을 비동기 전송 처리
즉, 커밋 완료 → 스프링 이벤트 발행 → 메시지 전송 요청 비동기 처리
```
예. 메시지0 저장(200ms) → 메시지1 저장(200ms) ..
       ↘ 메시지0 전송 요청         ↘ 메시지1 전송 요청
```
또한 메시지 전송시, WebSocket 전송 실패 가능성을 대비해 최대 3회까지 재전송 시도하는 로직 추가

### 2. `TradeChatMessageDto` 수정
Spring Event를 도입하며 Frontend에서 실제 시현을 진행했습니다. 그러나 메시지가 채팅방에 전송되지 않는 에러가 발생했습니다.
확인해본 결과 채팅 도메인을 java에서 kotlin으로 바꾸며 생긴 에러였습니다.
`TradeChatMessageDto`의 `sendNickName`, `sendDate`가 `nullable`이어야 에러가 발생하지 않습니다.
아마 `JSON` -> `TradeChatMessageDto` 로 변경될 때(클라이언트에서 서버로 데이터 전송될 때), `sendNickName`, `sendDate`가 `null`인 경우가 있어 생긴 문제 같습니다.

## ✅ 체크리스트 <!-- 체크 리스트를 작성해서 본인이 확인해보고 추가로 팀원이 리뷰할 때 확인 했으면 하는 부분 작성해주세요 -->

- [ ] 예외 처리 충분히 고려함
- [x] 코드 오류가 없음
- [x] 이슈 연결